### PR TITLE
Fix - Change sponsorhip email

### DIFF
--- a/src/js/sponsors.jsx
+++ b/src/js/sponsors.jsx
@@ -69,7 +69,7 @@ function Sponsors() {
       {_makeSponsors('small')}
       {_makeSponsors('smallest')}
       {_makeSponsors('tiny')}
-      <a href="mailto:hello@treehacks.com?Subject=Sponsorship%20Interest" className="apply-button">become a sponsor!</a>
+      <a href="mailto:sponsorship@treehacks.com?Subject=Sponsorship%20Interest" className="apply-button">become a sponsor!</a>
     </div>
   );
 }


### PR DESCRIPTION
This commit changes the email from `hello@treehacks.com` to `sponsorship@treehacks.com`