### PR TITLE
fix: missing `px` at sm screen (Sponsors & FAQs)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -593,13 +593,13 @@ const [lastScrollTop, setLastScrollTop] = useState(0); // Initialize the state
 
 
       <section className="w-full lg:pl-40 lg:pr-40 flex flex-col relative 8 lg:pb-16" id="sponsors">
-        <div className="lg:items-center flex flex-col">
+        <div className="items-center flex flex-col">
           <h1 className='text-center font-Raleway font-extrabold mb-8 bg-clip-text' style={{color: '#232323', fontSize: '36px', lineHeight: '1.2'}}>
                 Sponsors
           </h1>   
-          <p className=' description font-bold lg:text-center font-Raleway' style={{color: '#585858', fontSize: '18px', width: '80%'}}>
-          TreeHacks would not be possible without the support of our incredible sponsors. Throughout the event, they’ll host workshops, discuss job opportunities, host prizes, and much more.      
-            </p>
+          <p className='description font-bold text-center font-Raleway px-4' style={{color: '#585858', fontSize: '18px', width: '80%'}}>
+                TreeHacks would not be possible without the support of our incredible sponsors. Throughout the event, they’ll host workshops, discuss job opportunities, host prizes, and much more.      
+          </p>
         </div>
         <div className="pt-16 lg:pt-8 sponsorSection">
           {/* New Row */}
@@ -826,13 +826,13 @@ const [lastScrollTop, setLastScrollTop] = useState(0); // Initialize the state
 
       <section className="w-full lg:pl-40 lg:pr-40 md:pl-20 md:pr-20 flex flex-col relative" id="faqs">
       <img src={hootowImg} className="dissapearWhenSmall globe_img top-30 z-0 w-120 mb-160 right-20 absolute" alt="Hoover Tower" />
-        <div className="lg:items-center flex flex-col">
+        <div className="items-center flex flex-col">
           <h1 className='text-center font-Raleway font-extrabold mb-8 bg-clip-text' style={{color: '#232323', fontSize: '36px', lineHeight: '1.2'}}>
                 FAQs
           </h1>   
-          <p className=' description font-bold pb-10 lg:text-center font-Raleway' style={{color: '#585858', fontSize: '18px', width: '80%'}}>
-          Email us at hello@treehacks.com if we missed anything!
-            </p>
+          <p className='description font-bold pb-10 px-4 text-center font-Raleway' style={{color: '#585858', fontSize: '18px', width: '80%'}}>
+                Email us at hello@treehacks.com if we missed anything!
+          </p>
         </div>
 
         <div className="faqSection">


### PR DESCRIPTION
# Overview
The sponsors section and the FAQs section are missing horizontal peddings -- e.g. `px-4`.
They have correct paddings in bigger screens (md, lg, etc).
They are just missing these correct paddings in small screens.

The problem was caused by line #586 and #730 `lg:items-center`.
This commit fixes this issue by stripping `lg:` conditional and changing this to `items-center`.
Now, the padding is correct for all screen sizes, as checked by Chrome Developer tool's screen size testing tool.

### Before fix:
![Before fix, padding was incorrect.](https://github.com/TreeHacks/website/assets/19341857/69003b34-455c-4d8c-827d-fe88f4e533b8)

### After fix:
![This commit resolves this issue by correctly padding the descriptions in all screen sizes.](https://github.com/TreeHacks/website/assets/19341857/ba22506d-2b67-4477-84f6-e90184ca2717)
